### PR TITLE
Test fixes

### DIFF
--- a/src/sqlabstraction/implementations/expression_pgsql.php
+++ b/src/sqlabstraction/implementations/expression_pgsql.php
@@ -78,7 +78,7 @@ class ezcQueryExpressionPgsql extends ezcQueryExpression
         $column = $this->getIdentifier( $column );
         if ( $this->version > 7 )
         {
-            return "MD5( {$column} )";
+            return "MD5( {$column}::text )";
         }
         else
         {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,3 +12,6 @@ phpunit
 EOT
        );
 }
+
+ini_set( "date.timezone", "UTC" );
+

--- a/tests/factory_test.php
+++ b/tests/factory_test.php
@@ -25,11 +25,13 @@
  * @subpackage Tests
  */
 
+require_once __DIR__ . '/test_case.php';
+
 /**
  * @package Database
  * @subpackage Tests
  */
-class ezcDatabaseFactoryTest extends ezcTestCase
+class ezcDatabaseFactoryTest extends ezcDatabaseTestCase
 {
     public function testWithoutImplementationType()
     {

--- a/tests/handler_test.php
+++ b/tests/handler_test.php
@@ -25,26 +25,16 @@
  * @subpackage Tests
  */
 
+require_once __DIR__ . '/test_case.php';
+
 /**
  * Test the handler classes.
  *
  * @package Database
  * @subpackage Tests
  */
-class ezcDatabaseHandlerTest extends ezcTestCase
+class ezcDatabaseHandlerTest extends ezcDatabaseTestCase
 {
-    protected function setUp()
-    {
-        try
-        {
-            $db = ezcDbInstance::get();
-        }
-        catch ( Exception $e )
-        {
-            $this->markTestSkipped();
-        }
-    }
-
     public function testConstructorNoDatabaseName()
     {
         try

--- a/tests/instance_delayed_init_test.php
+++ b/tests/instance_delayed_init_test.php
@@ -25,6 +25,7 @@
  * @subpackage Tests
  */
 
+require_once __DIR__ . '/test_case.php';
 require_once 'test_classes.php';
 
 /**
@@ -33,12 +34,14 @@ require_once 'test_classes.php';
  * @package Database
  * @subpackage Tests
  */
-class ezcDatabaseInstanceDelayedInitTest extends ezcTestCase
+class ezcDatabaseInstanceDelayedInitTest extends ezcDatabaseTestCase
 {
     private $default;
 
     public function setUp()
     {
+        parent::setUp();
+
         if ( !ezcBaseFeatures::hasExtensionSupport( 'pdo_sqlite') )
         {
             $this->markTestSkipped();

--- a/tests/instance_test.php
+++ b/tests/instance_test.php
@@ -25,26 +25,21 @@
  * @subpackage Tests
  */
 
+require_once __DIR__ . '/test_case.php';
+
 /**
  * Test the instance class
  *
  * @package Database
  * @subpackage Tests
  */
-class ezcDatabaseInstanceTest extends ezcTestCase
+class ezcDatabaseInstanceTest extends ezcDatabaseTestCase
 {
     private $default;
 
     protected function setUp()
     {
-        try
-        {
-            $this->default = ezcDbInstance::get();
-        }
-        catch ( Exception $e )
-        {
-            $this->markTestSkipped();
-        }
+        $this->default = parent::setUp();
     }
 
     protected function tearDown()

--- a/tests/pdo_test.php
+++ b/tests/pdo_test.php
@@ -25,24 +25,19 @@
  * @subpackage Tests
  */
 
+require_once __DIR__ . '/test_case.php';
+
 /**
  * Test the PDO system.
  *
  * @package Database
  * @subpackage Tests
  */
-class ezcPdoTest extends ezcTestCase
+class ezcPdoTest extends ezcDatabaseTestCase
 {
     protected function setUp()
     {
-        try
-        {
-            $db = ezcDbInstance::get();
-        }
-        catch ( Exception $e )
-        {
-            $this->markTestSkipped();
-        }
+        $db = parent::setUp();
 
         $this->q = new ezcQueryInsert( $db );
         try

--- a/tests/sqlabstraction/expression_test.php
+++ b/tests/sqlabstraction/expression_test.php
@@ -25,6 +25,8 @@
  * @subpackage Tests
  */
 
+require_once __DIR__ . '/../test_case.php';
+
 /**
  * Testing the SQL expression abstraction layer.
  * This file tests that the methods actually produce correct output for the base
@@ -35,7 +37,7 @@
  * @subpackage Tests
  * @todo, test with null input values
  */
-class ezcQueryExpressionTest extends ezcTestCase
+class ezcQueryExpressionTest extends ezcDatabaseTestCase
 {
     private $q;
     private $e;
@@ -43,14 +45,7 @@ class ezcQueryExpressionTest extends ezcTestCase
 
     protected function setUp()
     {
-        
-        try {
-            $this->db = ezcDbInstance::get();
-        }
-        catch ( Exception $e )
-        {
-            $this->markTestSkipped();
-        }
+        $this->db = parent::setUp();
 
         $this->q = $this->db->createSelectQuery();
         $this->e = $this->db->createExpression();

--- a/tests/sqlabstraction/expression_test.php
+++ b/tests/sqlabstraction/expression_test.php
@@ -430,7 +430,7 @@ class ezcQueryExpressionTest extends ezcDatabaseTestCase
 
             if ( $pgSQL_version >= 8 ) 
             {
-                $reference = 'MD5( name )';
+                $reference = 'MD5( name::text )';
             }
             else
             {

--- a/tests/sqlabstraction/query_delete_test.php
+++ b/tests/sqlabstraction/query_delete_test.php
@@ -25,26 +25,21 @@
  * @subpackage Tests
  */
 
+require_once __DIR__ . '/../test_case.php';
+
 /**
  * Testing the SQL expression abstraction layer for INSERT queries.
  *
  * @package Database
  * @subpackage Tests
  */
-class ezcQueryDeleteTest extends ezcTestCase
+class ezcQueryDeleteTest extends ezcDatabaseTestCase
 {
     private $q;
 
     protected function setUp()
     {
-        try
-        {
-            $db = ezcDbInstance::get();
-        }
-        catch ( Exception $e )
-        {
-            $this->markTestSkipped();
-        }
+        $db = parent::setUp();
 
         $this->q = new ezcQueryDelete( $db );
         try

--- a/tests/sqlabstraction/query_insert_test.php
+++ b/tests/sqlabstraction/query_insert_test.php
@@ -25,26 +25,21 @@
  * @subpackage Tests
  */
 
+require_once __DIR__ . '/../test_case.php';
+
 /**
  * Testing the SQL expression abstraction layer for INSERT queries.
  *
  * @package Database
  * @subpackage Tests
  */
-class ezcQueryInsertTest extends ezcTestCase
+class ezcQueryInsertTest extends ezcDatabaseTestCase
 {
     private $q;
 
     protected function setUp()
     {
-        try
-        {
-            $db = ezcDbInstance::get();
-        }
-        catch ( Exception $e )
-        {
-            $this->markTestSkipped();
-        }
+        $db = parent::setUp();
 
         $this->q = new ezcQueryInsert( $db );
         try

--- a/tests/sqlabstraction/query_select_join_test.php
+++ b/tests/sqlabstraction/query_select_join_test.php
@@ -25,6 +25,8 @@
  * @subpackage Tests
  */
 
+require_once __DIR__ . '/../test_case.php';
+
 /**
  * Testing the JOIN functionality in the SQL abstraction layer.
  * These tests are performed on a real database and tests that
@@ -33,7 +35,7 @@
  * @package Database
  * @subpackage Tests
  */
-class ezcQuerySelectJoinTestImpl extends ezcTestCase
+class ezcQuerySelectJoinTestImpl extends ezcDatabaseTestCase
 {
     private $q;
     private $e;
@@ -41,14 +43,7 @@ class ezcQuerySelectJoinTestImpl extends ezcTestCase
 
     protected function setUp()
     {
-        try
-        {
-            $this->db = ezcDbInstance::get();
-        }
-        catch ( Exception $e )
-        {
-            $this->markTestSkipped();
-        }
+        $this->db = parent::setUp();
 
         $this->q = $this->db->createSelectQuery();
         $this->e = $this->q->expr;

--- a/tests/sqlabstraction/query_select_test.php
+++ b/tests/sqlabstraction/query_select_test.php
@@ -25,6 +25,8 @@
  * @subpackage Tests
  */
 
+require_once __DIR__ . '/../test_case.php';
+
 class TestSelect extends ezcQuerySelect
 {
     // @todo: Do we need the below? We use them for testing now, but
@@ -76,21 +78,14 @@ class TestSelect extends ezcQuerySelect
  * @subpackage Tests
  * @todo, test with null input values
  */
-class ezcQuerySelectTest extends ezcTestCase
+class ezcQuerySelectTest extends ezcDatabaseTestCase
 {
     private $q; // query
     private $e; // queryExpression
 
     protected function setUp()
     {
-        try
-        {
-            $db = ezcDbInstance::get();
-        }
-        catch ( Exception $e )
-        {
-            $this->markTestSkipped();
-        }
+        $db = parent::setUp();
 
         $this->q = new TestSelect( $db );
         $this->e = $this->q->expr;

--- a/tests/sqlabstraction/query_subselect_test.php
+++ b/tests/sqlabstraction/query_subselect_test.php
@@ -25,6 +25,8 @@
  * @subpackage Tests
  */
 
+require_once __DIR__ . '/../test_case.php';
+
 class TestSubSelect extends ezcQuerySelect
 {
     public $db;
@@ -73,20 +75,14 @@ class TestSubSelect extends ezcQuerySelect
  * @subpackage Tests
  * @todo, test with null input values
  */
-class ezcQuerySubSelectTest extends ezcTestCase
+class ezcQuerySubSelectTest extends ezcDatabaseTestCase
 {
     private $q; // query
     private $e; // queryExpression
+
     protected function setUp()
     {
-        try
-        {
-            $db = ezcDbInstance::get();
-        }
-        catch ( Exception $e )
-        {
-            $this->markTestSkipped();
-        }
+        $db = parent::setUp();
 
         $this->q = new TestSubSelect( $db );
         $this->e = $this->q->expr;

--- a/tests/sqlabstraction/query_test.php
+++ b/tests/sqlabstraction/query_test.php
@@ -25,6 +25,8 @@
  * @subpackage Tests
  */
 
+require_once __DIR__ . '/../test_case.php';
+
 /**
  * Dummy query impl.
  */
@@ -57,19 +59,21 @@ class MyQuery extends ezcQuery
 /**
  * Tests the base ezcQuery class
  */
-class ezcQueryTest extends ezcTestCase
+class ezcQueryTest extends ezcDatabaseTestCase
 {
     private $q;
 
     protected function setUp()
     {
+        parent::setUp();
+
         try
         {
             $this->q = new MyQuery();
         }
         catch ( Exception $e )
         {
-            $this->markTestSkipped();
+            $this->markTestSkipped( $e->getMessage() );
         }
     }
 

--- a/tests/sqlabstraction/query_update_test.php
+++ b/tests/sqlabstraction/query_update_test.php
@@ -25,25 +25,21 @@
  * @subpackage Tests
  */
 
+require_once __DIR__ . '/../test_case.php';
+
 /**
  * Testing the SQL expression abstraction layer for INSERT queries.
  *
  * @package Database
  * @subpackage Tests
  */
-class ezcQueryUpdateTest extends ezcTestCase
+class ezcQueryUpdateTest extends ezcDatabaseTestCase
 {
     private $q;
 
     protected function setUp()
     {
-        try {
-            $db = ezcDbInstance::get();
-        }
-        catch ( Exception $e )
-        {
-            $this->markTestSkipped();
-        }
+        $db = parent::setUp();
 
         $this->assertNotNull( $db, 'Database instance is not initialized.' );
 
@@ -219,6 +215,11 @@ class ezcQueryUpdateTest extends ezcTestCase
     // test for bug 10777
     function testUpdateWithFalseTest()
     {
+        if ( !class_exists( "ezcDbSchema" ) )
+        {
+            $this->markTestSkipped( "Test requires the DB Schema component." );
+        }
+
         // create the database
         $db = ezcDbInstance::get();
         // open schema

--- a/tests/test_case.php
+++ b/tests/test_case.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ * @version //autogentag//
+ * @filesource
+ * @package Database
+ * @subpackage Tests
+ */
+
+/**
+ * Test the handler classes.
+ *
+ * @package Database
+ * @subpackage Tests
+ */
+abstract class ezcDatabaseTestCase extends ezcTestCase
+{
+    /**
+     * We are using a static variable here, because otherwise too many
+     * connections to the database will be opened (and not closed again). This
+     * would overload the DB.
+     */
+    private static $connection;
+
+    protected function setUp()
+    {
+        if ( !self::$connection )
+        {
+            try
+            {
+                $dsn = getenv( 'DSN' ) ?: 'sqlite://:memory:';
+                self::$connection = ezcDbFactory::create( $dsn );
+                ezcDbInstance::set( self::$connection );
+            }
+            catch ( Exception $e )
+            {
+                $this->markTestSkipped( $e->getMessage() );
+            }
+        }
+
+        return self::$connection;
+    }
+}
+
+?>

--- a/tests/transactions_test.php
+++ b/tests/transactions_test.php
@@ -68,6 +68,7 @@ class ezcDatabaseTransactionsTest extends ezcTestCase
 {
     protected function setUp()
     {
+        $this->markTestIncomplete( "The ezcTestSettings class does not exist anywhere -- how was this ever supposed to wrok?" );
         try
         {
             $dbparams = ezcTestSettings::getInstance()->db->dsn;

--- a/tests/transactions_test.php
+++ b/tests/transactions_test.php
@@ -25,38 +25,7 @@
  * @subpackage Tests
  */
 
-/**
- * A factory to create a database connections
- * using previously set parameters.
- *
- * We use MyDB::create() to create a database connection from any place
- * without passing connection parameters every time.
- * (this is not the same as singleton since the connection is not stored in
- * a static member)
-
- * @package Database
- * @subpackage Tests
- */
-class MyDB
-{
-    static private $instance = null;
-    static private $dbParams = null;
-
-    static public function setParams( $dbParams )
-    {
-        self::$dbParams = $dbParams;
-    }
-
-    static public function create()
-    {
-        // create instance
-        if ( self::$dbParams === null )
-            throw new Exception( "Missing database " .
-                                 "connection parameteters." );
-
-        return ezcDbFactory::create( self::$dbParams );
-    }
-}
+require_once __DIR__ . '/test_case.php';
 
 /**
  * Testing how nested transactions work.
@@ -64,21 +33,11 @@ class MyDB
  * @package Database
  * @subpackage Tests
  */
-class ezcDatabaseTransactionsTest extends ezcTestCase
+class ezcDatabaseTransactionsTest extends ezcDatabaseTestCase
 {
     protected function setUp()
     {
-        $this->markTestIncomplete( "The ezcTestSettings class does not exist anywhere -- how was this ever supposed to wrok?" );
-        try
-        {
-            $dbparams = ezcTestSettings::getInstance()->db->dsn;
-            MyDB::setParams( $dbparams );
-            $this->db = MyDB::create();
-        }
-        catch ( Exception $e )
-        {
-            $this->markTestSkipped();
-        }
+        $this->db = parent::setUp();
     }
 
     // normal: test nested transactions


### PR DESCRIPTION
Fixes Database tests.

Breaks were mostly caused by removing important test classes from the UnitTest component.
