### PR TITLE
PHP 7.2 deprecation fixes

### DIFF
--- a/src/sqlabstraction/implementations/query_select_sqlite.php
+++ b/src/sqlabstraction/implementations/query_select_sqlite.php
@@ -171,13 +171,13 @@ class ezcQuerySelectSqlite extends ezcQuerySelect
             $reversedConditions = array_reverse( $rJoinPart['conditions'] );
 
             // adding first table.
-            list( $key, $val ) = each( $reversedTables ); 
+            $val = current( $reversedTables );
             $oneItemResult .= $val;
 
-            while ( list( $key, $nextCondition ) = each( $reversedConditions ) )
+            foreach( $reversedConditions as $key => $nextCondition )
             {
-                list( $key2, $nextTable ) = each( $reversedTables );   
-               $oneItemResult .= " LEFT JOIN {$nextTable} ON {$nextCondition}";
+                $nextTable = next( $reversedTables );
+                $oneItemResult .= " LEFT JOIN {$nextTable} ON {$nextCondition}";
             }
             $resultArray[] = $oneItemResult;
         }

--- a/tests/sqlabstraction/query_subselect_test.php
+++ b/tests/sqlabstraction/query_subselect_test.php
@@ -92,7 +92,7 @@ class ezcQuerySubSelectTest extends ezcTestCase
         $this->e = $this->q->expr;
     }
 
-    public function testSubSelect()
+    public function __construct()
     {
         $reference = '( SELECT column FROM table WHERE id = 1 )';
         $q2 = $this->q->subSelect();


### PR DESCRIPTION
Fixes:

```
 PHP | File:Line                                                                                          |             Type | Issue
 7.0 | /tests/sqlabstraction/query_subselect_test.php:95                                                  | method_name      | Method name testSubSelect:TestSubSelect (@php4_constructors) is deprecated. 
 7.2 | /src/sqlabstraction/implementations/query_select_sqlite.php:174                                    | function         | Function each() is deprecated. 
 7.2 | /src/sqlabstraction/implementations/query_select_sqlite.php:177                                    | function         | Function each() is deprecated. 
 7.2 | /src/sqlabstraction/implementations/query_select_sqlite.php:179                                    | function         | Function each() is deprecated. 
```